### PR TITLE
Feature/event-detail-ticket-sales

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -86,7 +86,23 @@ class Event(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     venue = models.ForeignKey(Venue, on_delete=models.CASCADE, related_name='events')
+
+    @property
+    def tickets_sold(self):
+        return sum(ticket.quantity for ticket in self.tickets.all()) # type: ignore
     
+    @property
+    def demand_message(self):
+        if not self.venue or self.venue.capacity == 0:
+            return "Capacidad indefinida"
+        
+        percent = (self.tickets_sold/self.venue.capacity)*100
+
+        if percent > 90:
+            return "Alta demanda"
+        elif percent < 10:
+            return "Baja demanda"
+
 
     def __str__(self):
         return self.title

--- a/app/models.py
+++ b/app/models.py
@@ -124,6 +124,11 @@ class Event(models.Model):
     @classmethod
     def new(cls, title, description, scheduled_at, organizer, categories=None, venue=None):
         # Validaciones y creación
+        errors = cls.validate(title, description, scheduled_at)
+
+        if errors:
+            return False, errors
+
         event = cls.objects.create(
             title=title,
             description=description,

--- a/app/models.py
+++ b/app/models.py
@@ -99,9 +99,11 @@ class Event(models.Model):
         percent = (self.tickets_sold/self.venue.capacity)*100
 
         if percent > 90:
-            return "Alta demanda"
+            return "ALTA"
         elif percent < 10:
-            return "Baja demanda"
+            return "BAJA"
+        else:
+            return "MEDIA"
 
 
     def __str__(self):

--- a/app/templates/app/event_detail.html
+++ b/app/templates/app/event_detail.html
@@ -40,7 +40,6 @@
                             <p class="mb-0">{{ event.organizer }}</p>
                         </div>
                     </div>
-                    <!-- Categorías -->
                     <div class="d-flex align-items-center mb-3">
                         <div class="bg-light rounded-circle p-2 me-3">
                             <i class="bi bi-tags text-primary"></i>
@@ -54,6 +53,14 @@
                             {% endfor %}
                         </div>
                     </div>
+                    {% if user_is_organizer %}
+                    <div class="alert alert-info d-flex align-items-center" role="alert">
+                        <div>
+                            <i class="bi bi-receipt"></i> <strong>Entradas vendidas:</strong> {{ tickets_sold }}<br>
+                            <i class="bi bi-bar-chart me-2"></i><strong>Demanda:</strong> {{ demand_message }}
+                        </div>
+                    </div>
+                    {% endif %}
                     <div class="card-footer text-end">
                         <a href="{% url 'buy_ticket' event.id %}" class="btn btn-success">
                             <i class="bi bi-cart-plus me-1"></i> Comprar

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import TestCase
 from django.utils import timezone
 
-from app.models import Event, User, Venue
+from app.models import Event, User, Venue, Ticket
 
 
 class EventModelTest(TestCase):
@@ -13,6 +13,13 @@ class EventModelTest(TestCase):
             email="organizador@example.com",
             password="password123",
             is_organizer=True,
+        )
+
+        self.not_organizer = User.objects.create_user(
+            username="not_organizer_test",
+            email="not_organizer@example.com",
+            password="password123",
+            is_organizer=False,
         )
 
         self.venue_mocked = Venue.objects.create(
@@ -154,3 +161,29 @@ class EventModelTest(TestCase):
         self.assertEqual(updated_event.title, original_title)
         self.assertEqual(updated_event.description, new_description)
         self.assertEqual(updated_event.scheduled_at, original_scheduled_at)
+
+    def test_event_tickets_sold_correct_total(self):
+        event_mocked = Event.objects.create(
+            title="Pelicula",
+            description="Descripción de la pelicula",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            venue = self.venue_mocked
+        )
+
+        Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=100, type="general")
+
+        self.assertEqual(event_mocked.tickets_sold, 100)
+
+    def test_event_tickets_sold_incorrect_total(self):
+        event_mocked = Event.objects.create(
+            title="Pelicula",
+            description="Descripción de la pelicula",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            venue = self.venue_mocked
+        )
+
+        Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=100, type="general")
+
+        self.assertNotEqual(event_mocked.tickets_sold, 400)    

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -3,7 +3,7 @@ import datetime
 from django.test import TestCase
 from django.utils import timezone
 
-from app.models import Event, User
+from app.models import Event, User, Venue
 
 
 class EventModelTest(TestCase):
@@ -15,13 +15,23 @@ class EventModelTest(TestCase):
             is_organizer=True,
         )
 
+        self.venue_mocked = Venue.objects.create(
+            name="Auditorio Nacional",
+            address="60 y 124",
+            capacity=5000,
+            country="ARG",  
+            city="La Plata"
+        )
+
     def test_event_creation(self):
         event = Event.objects.create(
             title="Evento de prueba",
             description="Descripción del evento de prueba",
             scheduled_at=timezone.now() + datetime.timedelta(days=1),
             organizer=self.organizer,
+            venue = self.venue_mocked
         )
+
         """Test que verifica la creación correcta de eventos"""
         self.assertEqual(event.title, "Evento de prueba")
         self.assertEqual(event.description, "Descripción del evento de prueba")
@@ -52,15 +62,16 @@ class EventModelTest(TestCase):
     def test_event_new_with_valid_data(self):
         """Test que verifica la creación de eventos con datos válidos"""
         scheduled_at = timezone.now() + datetime.timedelta(days=2)
-        success, errors = Event.new(
+        success, event = Event.new(
             title="Nuevo evento",
             description="Descripción del nuevo evento",
             scheduled_at=scheduled_at,
             organizer=self.organizer,
+            venue = self.venue_mocked
         )
 
         self.assertTrue(success)
-        self.assertIsNone(errors)
+        self.assertIsInstance(event, Event)
 
         # Verificar que el evento fue creado en la base de datos
         new_event = Event.objects.get(title="Nuevo evento")
@@ -78,6 +89,7 @@ class EventModelTest(TestCase):
             description="Descripción del evento",
             scheduled_at=scheduled_at,
             organizer=self.organizer,
+            venue = self.venue_mocked    
         )
 
         self.assertFalse(success)
@@ -97,6 +109,7 @@ class EventModelTest(TestCase):
             description="Descripción del evento de prueba",
             scheduled_at=timezone.now() + datetime.timedelta(days=1),
             organizer=self.organizer,
+            venue = self.venue_mocked
         )
 
         event.update(
@@ -120,6 +133,7 @@ class EventModelTest(TestCase):
             description="Descripción del evento de prueba",
             scheduled_at=timezone.now() + datetime.timedelta(days=1),
             organizer=self.organizer,
+            venue = self.venue_mocked
         )
 
         original_title = event.title

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -187,3 +187,44 @@ class EventModelTest(TestCase):
         Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=100, type="general")
 
         self.assertNotEqual(event_mocked.tickets_sold, 400)    
+
+    def test_event_demand_message_low(self):
+        event_mocked = Event.objects.create(
+            title="Pelicula",
+            description="Descripción de la pelicula",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            venue = self.venue_mocked
+        )
+
+        Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=100, type="general")
+        self.assertEqual(event_mocked.demand_message,  "BAJA")
+    
+    def test_event_demand_message_high(self):
+        event_mocked = Event.objects.create(
+            title="Pelicula",
+            description="Descripción de la pelicula",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            venue = self.venue_mocked
+        )
+
+        Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=4600, type="general")
+        self.assertEqual(event_mocked.demand_message,  "ALTA")
+
+    def test_event_demand_message_medium(self):
+        event_mocked = Event.objects.create(
+            title="Pelicula",
+            description="Descripción de la pelicula",
+            scheduled_at=timezone.now() + datetime.timedelta(days=1),
+            organizer=self.organizer,
+            venue = self.venue_mocked
+        )
+
+        Ticket.objects.create(user = self.not_organizer, event=event_mocked, quantity=700, type="general")
+        self.assertEqual(event_mocked.demand_message,  "MEDIA")
+        
+    
+
+        
+

--- a/app/views.py
+++ b/app/views.py
@@ -253,6 +253,16 @@ def event_detail(request, id):
         except Rating.DoesNotExist:
             form = Rating_Form()
     
+    is_organizer = request.user == event.organizer
+
+    if is_organizer:
+        tickets_sold = event.tickets_sold
+        demand_message = event.demand_message
+    else:
+        tickets_sold = None
+        demand_message = None
+
+
     return render(
         request, "app/event_detail.html", 
         {"event": event, 
@@ -262,7 +272,9 @@ def event_detail(request, id):
          "form": form,
          "editando": editando,
          "resena": resena_existente,
-         "cantidad_resenas": cantidad_resenas, 
+         "cantidad_resenas": cantidad_resenas,
+         "tickets_sold": tickets_sold,
+         "demand_message": demand_message 
         })
 
 @login_required


### PR DESCRIPTION
## Feature/event-detail-ticket-sales en base al issue #1 
---

## Issue
[Visualizar cantidad de entradas en el detalle del evento y tipo de demanda](https://github.com/RomeroSilvia/eventhub/issues/1)

---

##  Descripción de los cambios

Permitir que los organizadores puedan ver la cantidad de entradas vendidas en el detalle del evento, junto con un mensaje que avise si hay alta demanda (más del 90% de la ocupación), baja demanda (menos del 10% de la ocupación) o media demanda (en otro caso).

---

## Checklist de Criticidad

Marcá con [x] lo que corresponda:

- [x] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [x] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [ ] 🧪 Incluye pruebas automatizadas
- [ ] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema

---

## Notas adicionales (opcional)
Agregá información útil para el revisor:
- Screenshots
- Issues relacionadas
- Dependencias
- Observaciones específicas