### PR TITLE
Arreglo en view en 'event_detail'

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -280,7 +280,7 @@ def event_detail(request, id):
          "resena": resena_existente,
          "cantidad_resenas": cantidad_resenas,
          "tickets_sold": tickets_sold,
-         "demand_message": demand_message 
+         "demand_message": demand_message, 
          "rating_average": rating_average,
         })
 


### PR DESCRIPTION
##  Arreglo de error en 'event_detail' en view #3 

## Issue
[Visualizar el promedio de calificaciones solo al organizador del evento en su detalle evento](https://github.com/RomeroSilvia/eventhub/issues/3)

## Descripción de los cambios

Se insertó un "," (coma) faltante en la parte 'return' dé 'event_detail' en views, el cual no permitía ejecutar correctamente el código final.

---

## ✅ Checklist de Criticidad

Marca con [x] lo que corresponda:

- [x] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [ ] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [ ] 🧪 Incluye pruebas automatizadas
- [ ] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema

---

## 🗒️ Notas adicionales (opcional)
Ninguna
