### PR TITLE
Feature/event-detail-rating-average creacion de Test

### DIFF
--- a/app/templates/app/event_detail.html
+++ b/app/templates/app/event_detail.html
@@ -54,7 +54,7 @@
                         </div>
                     </div>
 
-                    {% if rating_average is not None %}
+                    {% if user == event.organizer and rating_average is not None %}
                         <div class="d-flex align-items-center mb-3">
                             <div class="bg-light rounded-circle p-2 me-3">
                                 <i class="bi bi-star text-primary"></i>

--- a/app/test/test_e2e/test_rating_average.py
+++ b/app/test/test_e2e/test_rating_average.py
@@ -1,0 +1,51 @@
+from django.urls import reverse
+from django.test import TestCase
+from app.models import Event, Rating, User, Venue
+from django.utils import timezone
+
+class RatingAverageVisibilityTest(TestCase):
+    def setUp(self):
+        self.organizer = User.objects.create_user(username="organizer", password="password123", is_organizer=True)
+        self.attendee = User.objects.create_user(username="usuario", password="password123", is_organizer=False)
+
+        self.venue = Venue.objects.create(
+            name='Auditorio UTN',
+            address='Av. Siempreviva 742',
+            capacity=200
+        )
+        
+        self.event1 = Event.objects.create(
+            title='Concierto de prueba',
+            description='Un evento de integración',
+            scheduled_at=timezone.now(),
+            organizer=self.organizer,
+            venue=self.venue
+        )
+
+        Rating.objects.create(evento=self.event1, usuario=self.organizer, titulo="Muy bueno", calificacion=4, texto="Me gustó mucho")
+        Rating.objects.create(evento=self.event1, usuario=self.attendee, titulo="No me gusto", calificacion=2)
+    
+    def test_rating_average_visible_only_to_organizer(self):
+        url = reverse("event_detail", args=[self.event1.id])
+
+        #No autenticado
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url) # type: ignore
+
+        #Autenticado, pero no organizador
+        self.client.login(username="usuario", password="password123")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Promedio de rating")
+        self.client.logout()
+
+        #Autenticado, y organizador
+        self.client.login(username="organizer", password="password123")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Calificación promedio")
+        self.assertContains(response, "3,0 / 5")
+
+        
+        

--- a/app/test/test_e2e/test_rating_average.py
+++ b/app/test/test_e2e/test_rating_average.py
@@ -31,7 +31,7 @@ class RatingAverageVisibilityTest(TestCase):
         #No autenticado
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/login", response.url) # type: ignore
+        self.assertIn("/login", response.url)
 
         #Autenticado, pero no organizador
         self.client.login(username="usuario", password="password123")

--- a/app/test/test_e2e/test_user.py
+++ b/app/test/test_e2e/test_user.py
@@ -1,6 +1,6 @@
 import re
 
-from playwright.sync_api import expect  # type: ignore
+from playwright.sync_api import expect 
 
 from app.models import User
 from app.test.test_e2e.base import BaseE2ETest

--- a/app/test/test_e2e/test_user.py
+++ b/app/test/test_e2e/test_user.py
@@ -1,6 +1,6 @@
 import re
 
-from playwright.sync_api import expect
+from playwright.sync_api import expect  # type: ignore
 
 from app.models import User
 from app.test.test_e2e.base import BaseE2ETest

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -90,7 +90,7 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
 
 
 class EventDetailViewTest(BaseEventTestCase):
@@ -117,7 +117,7 @@ class EventDetailViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
 
     def test_event_detail_view_with_invalid_id(self):
         """Test que verifica que la vista event_detail devuelve 404 cuando el evento no existe"""
@@ -158,7 +158,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertEqual(response.url, reverse("events")) # type: ignore
 
     def test_event_form_view_without_login(self):
         """Test que verifica que la vista event_form redirige a login cuando el usuario no está logueado"""
@@ -167,7 +167,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
 
     def test_event_form_edit_existing(self):
         """Test que verifica que se puede editar un evento existente"""
@@ -204,7 +204,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertEqual(response.url, reverse("events")) # type: ignore
 
         # Verificar que se creó el evento
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())
@@ -235,7 +235,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events"))
+        self.assertEqual(response.url, reverse("events")) # type: ignore
 
         # Verificar que el evento fue actualizado
         self.event1.refresh_from_db()
@@ -327,7 +327,7 @@ class EventDeleteViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
 
         # Verificar que el evento sigue existiendo
         self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -99,7 +99,7 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
+        self.assertTrue(response.url.startswith("/accounts/login/"))
 
 
 class EventDetailViewTest(BaseEventTestCase):
@@ -126,7 +126,7 @@ class EventDetailViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
+        self.assertTrue(response.url.startswith("/accounts/login/"))
 
     def test_event_detail_view_with_invalid_id(self):
         """Test que verifica que la vista event_detail devuelve 404 cuando el evento no existe"""
@@ -167,7 +167,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events")) # type: ignore
+        self.assertEqual(response.url, reverse("events"))
 
     def test_event_form_view_without_login(self):
         """Test que verifica que la vista event_form redirige a login cuando el usuario no está logueado"""
@@ -176,7 +176,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
+        self.assertTrue(response.url.startswith("/accounts/login/"))
 
     def test_event_form_edit_existing(self):
         """Test que verifica que se puede editar un evento existente"""
@@ -213,13 +213,13 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        #self.assertEqual(response.url, reverse("events")) # type: ignore
+        #self.assertEqual(response.url, reverse("events")) 
 
         # Verificar que se creó el evento
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())
         evento = Event.objects.get(title="Nuevo Evento")
 
-        self.assertEqual(response.url, reverse("event_detail", args=[evento.id])) # type: ignore
+        self.assertEqual(response.url, reverse("event_detail", args=[evento.id])) 
 
         self.assertEqual(evento.description, "Descripción del nuevo evento")
         self.assertEqual(evento.scheduled_at.year, 2025)
@@ -247,7 +247,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("event_detail", args=[self.event1.id])) # type: ignore
+        self.assertEqual(response.url, reverse("event_detail", args=[self.event1.id])) 
 
         # Verificar que el evento fue actualizado
         self.event1.refresh_from_db()
@@ -339,7 +339,7 @@ class EventDeleteViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/")) # type: ignore
+        self.assertTrue(response.url.startswith("/accounts/login/"))
 
         # Verificar que el evento sigue existiendo
         self.assertTrue(Event.objects.filter(pk=self.event1.id).exists())

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -213,7 +213,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        #self.assertEqual(response.url, reverse("events")) 
+        self.assertEqual(response.url, reverse("events")) 
 
         # Verificar que se creó el evento
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -5,7 +5,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from app.models import Event, User
+from app.models import Event, User, Venue
 
 
 class BaseEventTestCase(TestCase):
@@ -18,6 +18,13 @@ class BaseEventTestCase(TestCase):
             email="organizador@test.com",
             password="password123",
             is_organizer=True,
+        )
+
+        #Creacion de venue para los eventos
+        self.venue = Venue.objects.create(
+            name='Auditorio UTN',
+            address='Av. Siempreviva 742',
+            capacity=200
         )
 
         # Crear un usuario regular
@@ -34,6 +41,7 @@ class BaseEventTestCase(TestCase):
             description="Descripción del evento 1",
             scheduled_at=timezone.now() + datetime.timedelta(days=1),
             organizer=self.organizer,
+            venue=self.venue
         )
 
         self.event2 = Event.objects.create(
@@ -41,6 +49,7 @@ class BaseEventTestCase(TestCase):
             description="Descripción del evento 2",
             scheduled_at=timezone.now() + datetime.timedelta(days=2),
             organizer=self.organizer,
+            venue=self.venue
         )
 
         # Cliente para hacer peticiones
@@ -204,11 +213,14 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events")) # type: ignore
+        #self.assertEqual(response.url, reverse("events")) # type: ignore
 
         # Verificar que se creó el evento
         self.assertTrue(Event.objects.filter(title="Nuevo Evento").exists())
         evento = Event.objects.get(title="Nuevo Evento")
+
+        self.assertEqual(response.url, reverse("event_detail", args=[evento.id])) # type: ignore
+
         self.assertEqual(evento.description, "Descripción del nuevo evento")
         self.assertEqual(evento.scheduled_at.year, 2025)
         self.assertEqual(evento.scheduled_at.month, 5)
@@ -235,7 +247,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
 
         # Verificar que redirecciona a events
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("events")) # type: ignore
+        self.assertEqual(response.url, reverse("event_detail", args=[self.event1.id])) # type: ignore
 
         # Verificar que el evento fue actualizado
         self.event1.refresh_from_db()

--- a/app/test/test_integration/test_rating_average.py
+++ b/app/test/test_integration/test_rating_average.py
@@ -1,0 +1,49 @@
+from django.test import TestCase, Client
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from app.models import Event, Rating, Venue
+import datetime
+from django.utils import timezone
+
+User = get_user_model()
+
+class EventDetailIntegrationTest(TestCase):
+    def setUp(self):
+        self.organizer = User.objects.create_user(username='organizer', password='pass')
+        self.user = User.objects.create_user(username='user1', password='pass')
+
+        self.venue = Venue.objects.create(
+            name='Auditorio UTN',
+            address='Av. Siempreviva 742',
+            capacity=200
+        )
+        
+        self.event1 = Event.objects.create(
+            title='Concierto de prueba',
+            description='Un evento de integración',
+            scheduled_at=timezone.now() + datetime.timedelta(days=7),
+            organizer=self.organizer,
+            venue=self.venue
+        )
+
+        Rating.objects.create(
+            evento=self.event1, usuario=self.user,
+            titulo="Muy bueno", calificacion=4, texto="Me gustó mucho"
+        )
+
+        self.client = Client()
+
+    def test_rating_avegare_visible_organizer(self):
+        self.client.login(username='organizer', password='pass')
+        response = self.client.get(reverse('event_detail', args=[self.event1.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('rating_average', response.context)
+        self.assertEqual(response.context['rating_average'], 4)
+    
+    def test_rating_avegare_no_visible_others(self):
+        self.client.login(username='user1', password='pass')
+        response = self.client.get(reverse('event_detail', args=[self.event1.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['rating_average'])

--- a/app/test/test_unit/test_rating_average.py
+++ b/app/test/test_unit/test_rating_average.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import User
+from app.models import Event, Rating
+
+def test_rating_average_calculation():
+    organizer = User.objects.create_user(username="organizer", password="pass")
+    event = Event.objects.create(title="Evento Test", organizer=organizer)
+
+    Rating.objects.create(
+        evento=event, usuario=organizer,
+        titulo="Muy Bueno", calificacion=5, texto="El evento estuvo muy interesante"
+    )
+
+    Rating.objects.create(
+        evento=event, usuario=User.objects.create_user(username="user2", password="pass"),
+        titulo="No me intereso", calificacion=3, texto="El evento estuvo bien, pero puede mejorar"
+    )
+
+    Rating.objects.create(
+        evento=event, usuario=User.objects.create_user(username="user3", password="pass"),
+        titulo="Malo", calificacion=1, texto="No me gusto nada"
+    )
+
+    average = event.rating_average
+    assert round(average, 1) == 3.0

--- a/app/views.py
+++ b/app/views.py
@@ -347,7 +347,7 @@ def event_form(request, id=None):
             return redirect('event_detail', id=event.id)
 
         if success:
-            return redirect('event_detail', id=event_or_errors.id)
+            return redirect('event_detail', id=event_or_errors.id) # type: ignore
 
   
     event = None
@@ -362,9 +362,8 @@ def event_form(request, id=None):
 
     categories = list(Category.objects.all())
 
-   
     total = len(categories)
-    per_column = math.ceil(total / 3)
+    per_column = math.ceil(total / 3) if total > 0 else 1
     categories_chunks = [categories[i:i + per_column] for i in range(0, total, per_column)]
 
     context = {

--- a/app/views.py
+++ b/app/views.py
@@ -348,7 +348,7 @@ def event_form(request, id=None):
             return redirect('event_detail', id=event.id)
 
         if success:
-            return redirect('event_detail', id=event_or_errors.id) # type: ignore
+            return redirect('event_detail', id=event_or_errors.id)
 
   
     event = None


### PR DESCRIPTION
##  Creación de test para rating_average #3 


## Issue
[Visualizar el promedio de calificaciones solo al organizador del evento en su detalle evento](https://github.com/RomeroSilvia/eventhub/issues/3)

---

## Descripción de los cambios

Se incorporaron pruebas unitarias, de integración y end-to-end (E2E) relacionadas con la funcionalidad de rating_average:

- **Pruebas unitarias (test_unit/test_rating_average.py)**: se verificó que el cálculo del promedio de calificaciones sea correcto a partir de distintos conjuntos de valores.
- **Pruebas de integración (test_integration/test_rating_average.py)**: se válido que el valor del promedio de calificaciones sea visible únicamente para el organizador del evento.
- **Pruebas end-to-end (test_e2e/test_rating_average.py)**: se evaluó el comportamiento del sistema ante diferentes tipos de usuarios según su rol, como también comprobando su acceso y visibilidad al promedio de calificaciones.

---

## ✅ Checklist de Criticidad

Marcá con [x] lo que corresponda:

- [x] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [x] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [ ] 🧪 Incluye pruebas automatizadas
- [ ] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema

---

## 🗒️ Notas adicionales (opcional)
Ninguna
