### PR TITLE
Bugfixing/event-detail-ticket-sales 

### DIFF
--- a/app/test/test_e2e/test_tickets_sold_demand_message.py
+++ b/app/test/test_e2e/test_tickets_sold_demand_message.py
@@ -19,6 +19,12 @@ class EventDetailTest(BaseE2ETest):
         self.not_organizer = User.objects.create_user(
             username="not_organizer",
             password="password123",
+            is_organizer=True
+        )
+
+        self.regular= User.objects.create_user(
+            username="regular",
+            password="password123",
             is_organizer=False
         )
 
@@ -38,14 +44,25 @@ class EventDetailTest(BaseE2ETest):
 
     def test_organizer_sees_tickest_info_and_demand(self):
         self.login_user("organizer","password123")
+        self.page.goto(f"{self.live_server_url}/my_events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
         self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
         expect(self.page.get_by_text("Entradas vendidas:")).to_be_visible()
         expect(self.page.get_by_text("Demanda:")).to_be_visible()
 
     def test_not_organizer_does_not_see_tickest_info_and_demand(self):
         self.login_user("not_organizer","password123")
+        self.page.goto(f"{self.live_server_url}/events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
         self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
+        expect(self.page.get_by_text("Entradas vendidas:")).not_to_be_visible()
+        expect(self.page.get_by_text("Demanda:")).not_to_be_visible()
 
+    def test_regular_user_does_not_see_tickest_info_and_demand(self):
+        self.login_user("regular","password123")
+        self.page.goto(f"{self.live_server_url}/events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
+        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
         expect(self.page.get_by_text("Entradas vendidas:")).not_to_be_visible()
         expect(self.page.get_by_text("Demanda:")).not_to_be_visible()
 

--- a/app/test/test_integration/test_tickets_sold_demand_message.py
+++ b/app/test/test_integration/test_tickets_sold_demand_message.py
@@ -21,6 +21,13 @@ class BaseEventTestCase(TestCase):
             username="not_organizer",
             email="not_organizer@test.com",
             password="password123",
+            is_organizer=True,
+        )
+
+        self.regular = User.objects.create_user(
+            username="regular",
+            email="regular@test.com",
+            password="password123",
             is_organizer=False,
         )
 
@@ -51,7 +58,7 @@ class BaseEventTestCase(TestCase):
         self.assertContains(response, "ALTA")
 
 
-    def test_user_does_not_see_ticket_data_and_demand_message(self):
+    def test_not_organizer_does_not_see_ticket_data_and_demand_message(self):
         self.client.login(username="not_organizer", password="password123")
         Ticket.objects.create(user=self.not_organizer, event=self.event_mocked, quantity=950, type="general")
         response = self.client.get(reverse("event_detail", args=[self.event_mocked.id]))
@@ -62,3 +69,15 @@ class BaseEventTestCase(TestCase):
         self.assertNotContains(response, "ALTA")
         self.assertNotContains(response, "MEDIA")
         self.assertNotContains(response, "BAJA")
+
+    def test_regular_user_does_not_see_ticket_data_and_demand_message(self):
+        self.client.login(username="regular", password="password123")
+        Ticket.objects.create(user=self.regular, event=self.event_mocked, quantity=950, type="general")
+        response = self.client.get(reverse("event_detail", args=[self.event_mocked.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "app/event_detail.html")
+        self.assertNotContains(response, "950")
+        self.assertNotContains(response, "ALTA")
+        self.assertNotContains(response, "MEDIA")
+        self.assertNotContains(response, "BAJA")    


### PR DESCRIPTION
## 📌 Cambios en los test de integración y 2e2 de #1 

---

## 📌 Issue
[Visualizar cantidad de entradas en el detalle del evento y tipo de demanda](https://github.com/RomeroSilvia/eventhub/issues/1)

---

## 🧾 Descripción de los cambios

Cambios:

- Test de integración: se agregaron casos para cubrir todos los posibles escenarios (organizador del eventos, organizador pero no del evento, usuario regular) y qué se mostraría en cada caso
- Test e2e: se mejoró el recorrido que harian los usuarios (organizador del eventos, organizador pero no del evento, usuario regular) y qué se mostraría en cada caso


---

## ✅ Checklist de Criticidad

Marcá con [x] lo que corresponda:

- [x] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [ ] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [ ] 🧪 Incluye pruebas automatizadas
- [ ] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema

---

