### PR TITLE
Corregir Validaciones en la Creación de Validaciones

### DIFF
--- a/app/validations/notifications.py
+++ b/app/validations/notifications.py
@@ -3,6 +3,7 @@ def createNotificationValidations(user_ids, event_id, title, message, priority):
     errors = {}
     validations_pass = True
 
+    title = title.strip()
     if title == "":
         errors["title"] = "Por favor ingrese un titulo"
 
@@ -10,6 +11,7 @@ def createNotificationValidations(user_ids, event_id, title, message, priority):
     if len(title) > titleMaxLen:
         errors["title"] = "Maximo " + str(titleMaxLen) + " caracteres"
 
+    message = message.strip()
     if message == "":
         errors["message"] = "Por favor ingrese un mensaje"
 


### PR DESCRIPTION
## 📌 Corregir Validaciones en la Creación de Validaciones

---

## 📌 Issue
[Notificar Usuarios de Cambios en Eventos](https://github.com/RomeroSilvia/eventhub/issues/16)

---

## 🧾 Descripción de los cambios

Se arreglo un bug en las validaciones al crear una notificación. Un organizador debería poder crear notificaciones con un titulo y mensage en blanco. Esto era debido a que en el código no se eliminaban primero los espacios en blanco antes de preguntar si era igual a una cadena vacía. Con los cambios de la PR esa vulnerabilidad ya se encuentra solucionada.

Como valor agregado se crearon test unitarios para la función de **createNotificationsValidation**

---

## ✅ Checklist de Criticidad

- [ ] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [x] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [x] 🧪 Incluye pruebas automatizadas
- [x] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema