### PR TITLE
bugfixing/event-detail-ticket-sales-test-e2e

### DIFF
--- a/app/test/test_e2e/test_tickets_sold_demand_message.py
+++ b/app/test/test_e2e/test_tickets_sold_demand_message.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import expect
 from app.test.test_e2e.base import BaseE2ETest
-from app.models import User, Event, Venue
+from app.models import User, Event, Venue, Ticket
 
 import datetime
 from django.utils import timezone
@@ -42,28 +42,52 @@ class EventDetailTest(BaseE2ETest):
             venue=self.venue_mocked
         )
 
-    def test_organizer_sees_tickest_info_and_demand(self):
-        self.login_user("organizer","password123")
-        self.page.goto(f"{self.live_server_url}/my_events/")
-        self.page.get_by_role("link", name="Ver detalle").first.click()
-        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
-        expect(self.page.get_by_text("Entradas vendidas:")).to_be_visible()
-        expect(self.page.get_by_text("Demanda:")).to_be_visible()
-
-    def test_not_organizer_does_not_see_tickest_info_and_demand(self):
-        self.login_user("not_organizer","password123")
-        self.page.goto(f"{self.live_server_url}/events/")
-        self.page.get_by_role("link", name="Ver detalle").first.click()
-        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
-        expect(self.page.get_by_text("Entradas vendidas:")).not_to_be_visible()
-        expect(self.page.get_by_text("Demanda:")).not_to_be_visible()
-
     def test_regular_user_does_not_see_tickest_info_and_demand(self):
+        Ticket.objects.create(user=self.regular, event=self.event_mocked, quantity=1, type="general")
+
         self.login_user("regular","password123")
         self.page.goto(f"{self.live_server_url}/events/")
         self.page.get_by_role("link", name="Ver detalle").first.click()
         self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
         expect(self.page.get_by_text("Entradas vendidas:")).not_to_be_visible()
         expect(self.page.get_by_text("Demanda:")).not_to_be_visible()
+
+    def test_organizer_sees_high_demand(self):
+        Ticket.objects.create(user=self.regular, event=self.event_mocked, quantity=190, type="general")
+
+        self.login_user("organizer","password123")
+        self.page.goto(f"{self.live_server_url}/my_events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
+        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
+
+        expect(self.page.get_by_text("Entradas vendidas: 190")).to_be_visible()
+        expect(self.page.get_by_text("Demanda: ALTA")).to_be_visible()
+
+    def test_organizer_sees_low_demand(self):
+        Ticket.objects.create(user=self.regular, event=self.event_mocked, quantity=1, type="general")
+
+        self.login_user("organizer","password123")
+        self.page.goto(f"{self.live_server_url}/my_events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
+        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
+
+        expect(self.page.get_by_text("Entradas vendidas: 1")).to_be_visible()
+        expect(self.page.get_by_text("Demanda: BAJA")).to_be_visible()
+
+    def test_organizer_sees_medium_demand(self):
+        Ticket.objects.create(user=self.regular, event=self.event_mocked, quantity=40, type="general")
+
+        self.login_user("organizer","password123")
+        self.page.goto(f"{self.live_server_url}/my_events/")
+        self.page.get_by_role("link", name="Ver detalle").first.click()
+        self.page.goto(f"{self.live_server_url}/events/{self.event_mocked.pk}/")
+
+        expect(self.page.get_by_text("Entradas vendidas: 40")).to_be_visible()
+        expect(self.page.get_by_text("Demanda: MEDIA")).to_be_visible()
+        
+        
+
+
+
 
 


### PR DESCRIPTION
## 📌Cambios en los test  2e2 de #1 

---

## 📌 Issue
[Visualizar cantidad de entradas en el detalle del evento y tipo de demanda](https://github.com/RomeroSilvia/eventhub/issues/1)

---

## 🧾 Descripción de los cambios

Corrección pedida:

_Para testear e2e, solo buscan un texto pero no chequean que el contenido sea correcto. Por ejemplo que la interfaz efectivamente muestre la cantidad correcta de entradas vendidas._

- Se modificó el test `test_regular_user_does_not_see_tickest_info_and_demand  `para que, en caso de que compre una entrada, no le aparezca el ni la cantidad de entradas vendidas ni el mensaje de la demanda.
- Se crearon los test `test_organizer_sees_high_demand`, `test_organizer_sees_low_demand` y `test_organizer_sees_medium_demand` para que, dependiendo del caso, se muestre efectivamente la cantidad de entradas vendidas y el mensaje de demanda correspondiente.
- Se eliminaron los test `test_organizer_sees_tickest_info_and_demand `y `test_not_organizer_does_not_see_tickest_info_and_demand` porque no testaban bien la funcionalidad.

---

## ✅ Checklist de Criticidad

Marcá con [x] lo que corresponda:

- [ ] 🔁 Cambios menores (UI, texto, estilos, sin impacto funcional)
- [x] ⚙️ Cambios funcionales moderados (validaciones, reglas de negocio)
- [ ] 💣 Cambios críticos (afecta flujo de login, registro, pagos, etc.)
- [ ] 🧪 Incluye pruebas automatizadas
- [x] 🧑‍💻 Probado manualmente en entorno local
- [ ] 🧩 Requiere cambios en el backend o en otra parte del sistema


